### PR TITLE
Update for latest save system.

### DIFF
--- a/The Long Dark Save Editor 2/App.config
+++ b/The Long Dark Save Editor 2/App.config
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="The_Long_Dark_Save_Editor_2.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
-            <section name="The_Long_Dark_Save_Editor_2.Helpers.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+            <section name="The_Long_Dark_Save_Editor_2.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+            <section name="The_Long_Dark_Save_Editor_2.Helpers.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
     <userSettings>
         <The_Long_Dark_Save_Editor_2.Properties.Settings>
@@ -27,4 +27,24 @@
             </setting>
         </The_Long_Dark_Save_Editor_2.Helpers.Properties.Settings>
     </userSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/The Long Dark Save Editor 2/Game data/GlobalData.cs
+++ b/The Long Dark Save Editor 2/Game data/GlobalData.cs
@@ -16,7 +16,7 @@ namespace The_Long_Dark_Save_Editor_2.Game_data
         public string m_Timestamp { get; set; }
         public EnumWrapper<SaveSlotType> m_GameMode { get; set; }
         public uint m_GameId { get; set; }
-        public Dictionary<string, byte[]> m_Dict { get; set; }
+        public Dictionary<string, string> m_Dict { get; set; }
     }
 
     public class GameManagerData

--- a/The Long Dark Save Editor 2/GameSave.cs
+++ b/The Long Dark Save Editor 2/GameSave.cs
@@ -34,11 +34,11 @@ namespace The_Long_Dark_Save_Editor_2
             string slotJson = EncryptString.Decompress(File.ReadAllBytes(path));
             dynamicSlotData = new DynamicSerializable<SlotData>(slotJson);
 
-            var bootJson = EncryptString.Decompress(SlotData.m_Dict["boot"]);
+            var bootJson = EncryptString.Decompress(Convert.FromBase64String(SlotData.m_Dict["boot"]));
             dynamicBoot = new DynamicSerializable<BootSaveGameFormat>(bootJson);
             OriginalRegion = Boot.m_SceneName.Value;
 
-            var globalJson = EncryptString.Decompress(SlotData.m_Dict["global"]);
+            var globalJson = EncryptString.Decompress(Convert.FromBase64String(SlotData.m_Dict["global"]));
             dynamicGlobal = new DynamicSerializable<GlobalSaveGameFormat>(globalJson);
 
             Afflictions = new AfflictionsContainer(Global);
@@ -50,7 +50,7 @@ namespace The_Long_Dark_Save_Editor_2
 
             LastSaved = DateTime.Now.Ticks;
             var bootSerialized = dynamicBoot.Serialize();
-            SlotData.m_Dict["boot"] = EncryptString.Compress(bootSerialized);
+            SlotData.m_Dict["boot"] = Convert.ToBase64String(EncryptString.Compress(bootSerialized));
 
             if (Boot.m_SceneName.Value != OriginalRegion)
             {
@@ -62,7 +62,7 @@ namespace The_Long_Dark_Save_Editor_2
             Afflictions.SerializeTo(Global);
 
             var globalSerialized = dynamicGlobal.Serialize();
-            SlotData.m_Dict["global"] = EncryptString.Compress(globalSerialized);
+            SlotData.m_Dict["global"] = Convert.ToBase64String(EncryptString.Compress(globalSerialized));
 
             SlotData.m_Timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
             var slotDataSerialized = dynamicSlotData.Serialize();

--- a/The Long Dark Save Editor 2/MainWindow.xaml
+++ b/The Long Dark Save Editor 2/MainWindow.xaml
@@ -84,13 +84,13 @@
                 <StackPanel Orientation="Horizontal" Grid.Column="1" Margin="0 0 20 0">
                     <Button Style="{StaticResource MaterialDesignFlatButtonNoRounding}" Foreground="#7289DA" Click="JoinDiscordClicked" Height="40">
                         <StackPanel Orientation="Horizontal">
-                            <materialDesign:PackIcon Kind="Discord" Width="18" Height="18" />
+								<materialDesign:PackIcon Kind="Chat" Width="18" Height="18" />
                             <TextBlock Margin="8 0 0 0" VerticalAlignment="Center">Discord group</TextBlock>
                         </StackPanel>
                     </Button>
                     <Button Style="{StaticResource MaterialDesignFlatButtonNoRounding}" Foreground="#211F1F" Click="ViewOnGitHubClicked" Height="40">
                         <StackPanel Orientation="Horizontal">
-                            <materialDesign:PackIcon Kind="GithubCircle" Height="20" Width="20" />
+                            <materialDesign:PackIcon Kind="Github" Height="20" Width="20" />
                             <TextBlock Margin="8 0 0 0" VerticalAlignment="Center">View on GitHub</TextBlock>
                         </StackPanel>
                     </Button>

--- a/The Long Dark Save Editor 2/MainWindow.xaml.cs
+++ b/The Long Dark Save Editor 2/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace The_Long_Dark_Save_Editor_2
     public partial class MainWindow : Window, INotifyPropertyChanged
     {
         public static MainWindow Instance { get; set; }
-        public static VersionData Version { get { return new VersionData() { version = "2.18" }; } }
+        public static VersionData Version { get { return new VersionData() { version = "2.19" }; } }
 
         private GameSave currentSave;
         public GameSave CurrentSave { get { return currentSave; } set { SetPropertyField(ref currentSave, value); } }
@@ -139,7 +139,7 @@ namespace The_Long_Dark_Save_Editor_2
 
         private void UpdateSaves()
         {
-            var path = Path.Combine(Util.GetLocalPath(), testBranch ? "HinterlandTest2" : "Hinterland", "TheLongDark");
+            var path = Path.Combine(Util.GetLocalPath(), testBranch ? "HinterlandTest2" : "Hinterland", "TheLongDark", "Survival");
             Debug.WriteLine(path);
 
             if (Directory.Exists(path))

--- a/The Long Dark Save Editor 2/Serialization/DynamicSerializable.cs
+++ b/The Long Dark Save Editor 2/Serialization/DynamicSerializable.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using The_Long_Dark_Save_Editor_2.Helpers;
 
 namespace The_Long_Dark_Save_Editor_2.Serialization
 {

--- a/The Long Dark Save Editor 2/Tabs/AboutTab.xaml
+++ b/The Long Dark Save Editor 2/Tabs/AboutTab.xaml
@@ -6,28 +6,44 @@
              xmlns:local="clr-namespace:The_Long_Dark_Save_Editor_2.Tabs"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             d:DesignHeight="300" Width="401">
 
     <StackPanel Margin="0 20" >
         <Button MaxWidth="230" Style="{StaticResource MaterialDesignFlatButtonNoRounding}" Foreground="#211F1F" Click="ViewOnGithubClicked" Height="40">
             <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Height="24" Width="24" Kind="GithubCircle" VerticalAlignment="Center" />
+                <materialDesign:PackIcon Height="24" Width="24" Kind="Github" VerticalAlignment="Center" />
                 <TextBlock Margin="8 0 0 0" FontSize="20" VerticalAlignment="Center">View on GitHub</TextBlock>
             </StackPanel>
         </Button>
         <Label HorizontalAlignment="Center" Margin="0 10 0 0">Developed by FINDarkside</Label>
         <Label HorizontalAlignment="Center">Contact: findarkside@gmail.com</Label>
         <Label HorizontalAlignment="Center">Maps made by Whiteberry, Stray Wolf, stmSantana</Label>
-        <TextBlock HorizontalAlignment="Center" Style="{StaticResource MaterialDesignTitleTextBlock}" Margin="0 15 0 0">Other contributors:</TextBlock>
-        <Label HorizontalAlignment="Center">nbernier</Label>
-        <Label HorizontalAlignment="Center">Pt-Djefferson</Label>
-        <Label HorizontalAlignment="Center">ProsPex270</Label>
-        <Label HorizontalAlignment="Center" >RobertEves92</Label>
-        <TextBlock HorizontalAlignment="Center" Style="{StaticResource MaterialDesignTitleTextBlock}" Margin="0 15 0 0">Translations:</TextBlock>
-        <Label HorizontalAlignment="Center" >driver_13</Label>
-        <Label HorizontalAlignment="Center" >Boer17</Label>
-        <Label HorizontalAlignment="Center" >DaimeneX</Label>
-        <Label HorizontalAlignment="Center" >Martins96</Label>
-        <Label HorizontalAlignment="Center" >RobertEves92</Label>
-    </StackPanel>
+		<Grid>
+			<!-- Define Columns -->
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*"/>
+				<ColumnDefinition Width="*"/>
+			</Grid.ColumnDefinitions>
+			<StackPanel Grid.Column="0" Margin="10 0 10 0" >
+				<TextBlock HorizontalAlignment="Center" Style="{StaticResource MaterialDesignHeadline6TextBlock}" Margin="0 15 0 0">Other contributors:</TextBlock>
+				<Label HorizontalAlignment="Center">nbernier</Label>
+				<Label HorizontalAlignment="Center">Pt-Djefferson</Label>
+				<Label HorizontalAlignment="Center">ProsPex270</Label>
+				<Label HorizontalAlignment="Center" >RobertEves92</Label>
+				<Label HorizontalAlignment="Center" >MostHostLA</Label>
+			</StackPanel>
+			<StackPanel Grid.Column="1" Margin="10 0 10 0">
+				<TextBlock HorizontalAlignment="Center" Style="{StaticResource MaterialDesignHeadline6TextBlock}" Margin="0 15 0 0">Translations:</TextBlock>
+				<Label HorizontalAlignment="Center" >driver_13</Label>
+				<Label HorizontalAlignment="Center" >Boer17</Label>
+				<Label HorizontalAlignment="Center" >DaimeneX</Label>
+				<Label HorizontalAlignment="Center" >Martins96</Label>
+				<Label HorizontalAlignment="Center" >RobertEves92</Label>
+			</StackPanel>
+		</Grid>
+
+		<StackPanel Orientation="Horizontal">
+		    
+		</StackPanel>
+	</StackPanel>
 </UserControl>

--- a/The Long Dark Save Editor 2/Tabs/MapTab.xaml
+++ b/The Long Dark Save Editor 2/Tabs/MapTab.xaml
@@ -24,7 +24,7 @@
 
     </UserControl.Resources>
     <Canvas x:Name="canvas" Height="{Binding ActualHeight, ElementName=userControl, Mode=OneWay}" MouseLeftButtonDown="canvas_MouseLeftButtonDown" MouseWheel="canvas_MouseWheel" MouseMove="canvas_MouseMove"  
-        MouseLeftButtonUp="canvas_MouseLeftButtonUp" Width="{Binding ActualWidth, ElementName=userControl, Mode=OneWay}" ClipToBounds="True" Background="#00000000" >
+        MouseLeftButtonUp="canvas_MouseLeftButtonUp" Width="{Binding ActualWidth, ElementName=userControl, Mode=OneWay}" ClipToBounds="True" Background="#00000000" VerticalAlignment="Bottom" >
         <Viewbox x:Name="mapLayer" Height="{Binding ActualHeight, ElementName=mapImage, Mode=OneWay}" Width="{Binding ActualWidth, ElementName=mapImage, Mode=OneWay}" RenderTransformOrigin="0,0">
             <Viewbox.RenderTransform>
                 <TransformGroup>
@@ -46,7 +46,7 @@
             </Canvas>
         </Viewbox>
         <Grid Width="{Binding ActualWidth, ElementName=canvas, Mode=OneWay}" Height="{Binding ActualHeight, ElementName=canvas, Mode=OneWay}" d:IsHidden="True">
-            <TextBlock x:Name="canvasLabel" Style="{StaticResource MaterialDesignDisplay3TextBlock}" Foreground="{StaticResource MaterialDesignBody}" HorizontalAlignment="Center" VerticalAlignment="Center"><Run Text="asdasd"/></TextBlock>
+			<TextBlock x:Name="canvasLabel" Style="{StaticResource MaterialDesignHeadline2TextBlock}" Foreground="{StaticResource MaterialDesignBody}" HorizontalAlignment="Center" VerticalAlignment="Center"><Run Text="asdasd"/></TextBlock>
         </Grid>
     </Canvas>
 </UserControl>

--- a/The Long Dark Save Editor 2/The Long Dark Save Editor 2.csproj
+++ b/The Long Dark Save Editor 2/The Long Dark Save Editor 2.csproj
@@ -29,6 +29,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -55,27 +57,43 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dragablz, Version=0.0.3.186, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Dragablz.0.0.3.186\lib\net45\Dragablz.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Dragablz, Version=0.0.3.234, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Dragablz.0.0.3.234\lib\net45\Dragablz.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.4.2.13, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.1.4.2\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="MaterialDesignColors, Version=1.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MaterialDesignColors.1.1.3\lib\net45\MaterialDesignColors.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MaterialDesignColors, Version=2.1.4.0, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.2.1.4\lib\net462\MaterialDesignColors.dll</HintPath>
     </Reference>
-    <Reference Include="MaterialDesignThemes.Wpf, Version=2.3.0.823, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MaterialDesignThemes.2.3.0.823\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=4.9.0.0, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.4.9.0\lib\net462\MaterialDesignThemes.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.77\lib\net462\Microsoft.Xaml.Behaviors.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -311,6 +329,13 @@
     <Resource Include="Images\AshCanyonRegion.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MaterialDesignThemes.4.9.0\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.4.9.0\build\MaterialDesignThemes.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MaterialDesignThemes.4.9.0\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.4.9.0\build\MaterialDesignThemes.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/The Long Dark Save Editor 2/packages.config
+++ b/The Long Dark Save Editor 2/packages.config
@@ -1,8 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dragablz" version="0.0.3.186" targetFramework="net45" />
-  <package id="MaterialDesignColors" version="1.1.3" targetFramework="net45" />
-  <package id="MaterialDesignThemes" version="2.3.0.823" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-  <package id="SharpZipLib" version="1.3.3" targetFramework="net45" />
+  <package id="Dragablz" version="0.0.3.234" targetFramework="net48" />
+  <package id="MaterialDesignColors" version="2.1.4" targetFramework="net48" />
+  <package id="MaterialDesignThemes" version="4.9.0" targetFramework="net48" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.77" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="SharpZipLib" version="1.4.2" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Note that the path of the save files is locked into the Survival folder.

Wintermute save files tend to fail to load.

Base64 Compression decoding/encoding to read and save files. About/Contributor fix. Material Icon Changes. Packages bump. Version Increment.

Will add secondary sub-folder selector to allow changing it this xmas.